### PR TITLE
Eradicate category tables

### DIFF
--- a/migrations/versions/8d9d8ccd6476_eradicate_category_movies.py
+++ b/migrations/versions/8d9d8ccd6476_eradicate_category_movies.py
@@ -1,0 +1,116 @@
+"""Eradicate category_movies
+
+Revision ID: 8d9d8ccd6476
+Revises: 97296e3225e2
+Create Date: 2021-05-17 23:58:54.685789
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+from sqlalchemy import table, Integer, Column
+
+revision = "8d9d8ccd6476"
+down_revision = "97296e3225e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Migrate normal movies
+    op.add_column(
+        "movies",
+        sa.Column("category_id", sa.Integer(), nullable=False, server_default="10000"),
+    )
+    op.create_foreign_key(
+        None, "movies", "categories", ["category_id"], ["category_id"]
+    )
+
+    movies = table(
+        "movies",
+        Column("movie_id", Integer, primary_key=True, unique=True),
+        Column("category_id", Integer),
+    )
+    category_movies = table(
+        "category_movies",
+        Column("category_id", Integer, primary_key=True),
+        Column("movie_id", Integer, primary_key=True, unique=True),
+    )
+    op.execute(
+        movies.update()
+        .where(movies.c.movie_id == category_movies.c.movie_id)
+        .values(
+            {
+                movies.c.category_id: category_movies.c.category_id,
+            }
+        )
+    )
+
+    # Migrate pay movies
+    pay_movies = table(
+        "pay_movies",
+        Column("movie_id", Integer, primary_key=True, unique=True),
+        Column("category_id", Integer),
+    )
+    category_pay_movies = table(
+        "category_pay_movies",
+        Column("category_id", Integer, primary_key=True),
+        Column("movie_id", Integer, primary_key=True, unique=True),
+    )
+
+    op.alter_column(
+        "pay_movies",
+        "category_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+        server_default="20001",
+    )
+    op.create_foreign_key(
+        None, "pay_movies", "pay_categories", ["category_id"], ["category_id"]
+    )
+
+    op.execute(
+        pay_movies.update()
+        .where(pay_movies.c.movie_id == category_pay_movies.c.movie_id)
+        .values(
+            {
+                pay_movies.c.category_id: category_pay_movies.c.category_id,
+            }
+        )
+    )
+
+    op.drop_table("category_movies")
+    op.drop_table("category_pay_movies")
+
+
+def downgrade():
+    op.create_table(
+        "category_pay_movies",
+        sa.Column("category_id", sa.INTEGER(), autoincrement=False, nullable=True),
+        sa.Column("movie_id", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.PrimaryKeyConstraint("movie_id", name="category_pay_movies_pkey"),
+        sa.UniqueConstraint("movie_id", name="category_pay_movies_movie_id_key"),
+    )
+    op.create_table(
+        "category_movies",
+        sa.Column("category_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("movie_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["category_id"],
+            ["categories.category_id"],
+            name="category_movies_category_id_fkey",
+        ),
+        sa.ForeignKeyConstraint(
+            ["movie_id"], ["movies.movie_id"], name="category_movies_movie_id_fkey"
+        ),
+        sa.PrimaryKeyConstraint("category_id", "movie_id", name="category_movies_pkey"),
+    )
+
+    op.drop_constraint(None, "pay_movies", type_="foreignkey")
+    op.alter_column(
+        "pay_movies", "category_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.drop_constraint(None, "movies", type_="foreignkey")
+    op.drop_column("movies", "category_id")

--- a/models.py
+++ b/models.py
@@ -121,6 +121,12 @@ class MiiMsgInfo(db.Model):
 
 class Movies(db.Model):
     movie_id = db.Column(db.Integer, primary_key=True, unique=True)
+    category_id = db.Column(
+        db.Integer,
+        db.ForeignKey("categories.category_id"),
+        primary_key=True,
+        nullable=False,
+    )
     title = db.Column(db.String(48), nullable=False)
     length = db.Column(db.String(8), nullable=False)
     aspect = db.Column(db.Boolean, nullable=False)
@@ -139,7 +145,12 @@ class PayMovies(db.Model):
     note = db.Column(db.String(76), nullable=False)
     price = db.Column(db.Integer, nullable=False)
     released = db.Column(db.String(10), nullable=False)
-    category_id = db.Column(db.Integer)
+    category_id = db.Column(
+        db.Integer,
+        db.ForeignKey("pay_categories.category_id"),
+        primary_key=True,
+        nullable=False,
+    )
     date_added = db.Column(db.DateTime, nullable=False, server_default=func.now())
 
 
@@ -150,11 +161,6 @@ class PayCategories(db.Model):
     genre_id = db.Column(db.Integer)
 
 
-class CategoryPayMovies(db.Model):
-    category_id = db.Column(db.Integer)
-    movie_id = db.Column(db.Integer, primary_key=True, unique=True)
-
-
 class PayCategoryHeaders(db.Model):
     title = db.Column(db.String, primary_key=True, unique=True)
 
@@ -162,21 +168,6 @@ class PayCategoryHeaders(db.Model):
 class Categories(db.Model):
     category_id = db.Column(db.Integer, primary_key=True, unique=True)
     name = db.Column(db.String)
-
-
-class CategoryMovies(db.Model):
-    category_id = db.Column(
-        db.Integer,
-        db.ForeignKey("categories.category_id"),
-        primary_key=True,
-        nullable=False,
-    )
-    movie_id = db.Column(
-        db.Integer,
-        db.ForeignKey("movies.movie_id"),
-        primary_key=True,
-        nullable=False,
-    )
 
 
 class RoomBGMTypes(enum.Enum):

--- a/templates/movie_list.html
+++ b/templates/movie_list.html
@@ -17,7 +17,7 @@
         </tr>
         </thead>
         <tbody>
-        {% for movie, _ in movies.items %}
+        {% for movie in movies.items %}
             <tr>
                 <td>{{ movie.movie_id }}</td>
                 <td>{{ movie.title }}</td>

--- a/templates/pay_movie_list.html
+++ b/templates/pay_movie_list.html
@@ -17,7 +17,7 @@
         </tr>
         </thead>
         <tbody>
-        {% for movie, _ in movies.items %}
+        {% for movie in movies.items %}
             <tr>
                 <td>{{ movie.movie_id }}</td>
                 <td>{{ movie.title }}</td>

--- a/theunderground/pay_movies.py
+++ b/theunderground/pay_movies.py
@@ -9,7 +9,7 @@ from flask import (
 from flask_login import login_required
 
 from config import video_deletion_enabled
-from models import PayMovies, CategoryPayMovies
+from models import PayMovies
 from room import app, db, es
 from theunderground.mobiclip import (
     get_pay_category_list,
@@ -29,11 +29,8 @@ def list_pay_movies(category):
     page_num = request.args.get("page", default=1, type=int)
 
     # We want at most 10 posters per page.
-    movies = (
-        db.session.query(PayMovies, CategoryPayMovies)
-        .filter(CategoryPayMovies.category_id == category)
-        .filter(CategoryPayMovies.movie_id == PayMovies.movie_id)
-        .paginate(page_num, 20, error_out=False)
+    movies = PayMovies.query.filter(PayMovies.category_id == category).paginate(
+        page_num, 20, error_out=False
     )
 
     return render_template(
@@ -77,13 +74,6 @@ def add_pay_movie():
                 )
 
                 db.session.add(db_movie)
-                db.session.commit()
-
-                db.session.add(
-                    CategoryPayMovies(
-                        category_id=form.category.data, movie_id=db_movie.movie_id
-                    )
-                )
                 db.session.commit()
 
                 # Now that we've inserted the movie, we can properly move it.

--- a/url1/category_search.py
+++ b/url1/category_search.py
@@ -1,7 +1,7 @@
 from werkzeug import exceptions
 
-from models import CategoryMovies, Movies
-from room import app, db
+from models import Movies
+from room import app
 from helpers import xml_node_name, RepeatedElement, current_date_and_time
 
 
@@ -9,9 +9,7 @@ from helpers import xml_node_name, RepeatedElement, current_date_and_time
 @xml_node_name("SearchMovies")
 def list_category_search(categ_id):
     retrieved_data = (
-        db.session.query(CategoryMovies, Movies)
-        .filter(CategoryMovies.category_id == categ_id)
-        .filter(CategoryMovies.movie_id == Movies.movie_id)
+        Movies.query.filter(Movies.category_id == categ_id)
         .order_by(Movies.movie_id)
         .all()
     )
@@ -21,9 +19,7 @@ def list_category_search(categ_id):
         # Looks like this category does not exist, or contains no movies.
         return exceptions.NotFound()
 
-    for i, data in enumerate(retrieved_data):
-        _, movie_data = data
-
+    for i, movie_data in enumerate(retrieved_data):
         # Items must be indexed by 1.
         results.append(
             RepeatedElement(

--- a/url2/related.py
+++ b/url2/related.py
@@ -1,7 +1,7 @@
 from flask import request
 from werkzeug import exceptions
 
-from models import CategoryMovies, Movies
+from models import Movies
 from room import app, db
 from helpers import xml_node_name, RepeatedElement
 
@@ -16,16 +16,14 @@ def miiinfo():
 @xml_node_name("RelatedMovies")
 def related():
     movie = request.args.get("movieid")
-    category_result = CategoryMovies.query.filter_by(movie_id=movie).first()
+    category_result = Movies.query.filter_by(movie_id=movie).first()
     if category_result is None:
         return exceptions.NotFound()
 
     category_id = category_result.category_id
 
     movies = (
-        db.session.query(CategoryMovies, Movies)
-        .filter(CategoryMovies.category_id == category_id)
-        .filter(CategoryMovies.movie_id == Movies.movie_id)
+        Movies.quer.filter(Movies.category_id == category_id)
         .order_by(Movies.date_added)
         .limit(15)
         .all()
@@ -37,7 +35,7 @@ def related():
     # Our loop will increment it before using it as a rank.
     rank = 0
 
-    for _, movie in movies:
+    for movie in movies:
         rank += 1
         movie_info.append(
             RepeatedElement(


### PR DESCRIPTION
Consider the following:
```py
retrieved_data = (
     db.session.query(CategoryMovies, Movies)
    .filter(CategoryMovies.movie_id == Movies.movie_id)
     Movies.query.filter(Movies.category_id == categ_id)
    .order_by(Movies.movie_id)
    .all()
)
```
We have to effectively look up the `category_movies` table for all movie IDs matching that ID, and then query the `movies` table once more. And even worse, this is one of the key routes of our application. While performant isn't abysmal doing so, it just makes you wonder why when many uses follow similar immediately after:
```py
_, movies = retrieved_data
```

Additionally, `pay_movies` already had a `category_id` column, yet we preferred the use of the `category_pay_movies` table.

So now they've been obliterated. Included within the alembic migration is a migration from the separate tables to update `movies` and `pay_movies` respectively, and then delete. I did not bother writing such logic for a downgrade, and I hope nobody needs to.

---
I've tested this within both the panel and so forth along with manually searching code, but I'd still prefer this be tested a little more if possible.