### PR TITLE
Flask version correct

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=2.2
+Flask==2.2
 lxml>=4.8
 psycopg2>=2.9
 flask_sqlalchemy>=3.0.3


### PR DESCRIPTION
Python give " Error 'Flask' object has no attribute 'before_first_request' " because before_first_request has been removed on version 2.3