### PR TITLE
fix: Add logs migration syntax error

### DIFF
--- a/migrations/versions/01cda65b0957_add_logs_table.py
+++ b/migrations/versions/01cda65b0957_add_logs_table.py
@@ -23,8 +23,8 @@ create table logs
     id     serial
         primary key,
     action varchar not null,
-    "user" varchar not null
-    timestamp timestamp not null
+    "user" varchar not null,
+    "timestamp" timestamp not null
 );
      """)
 


### PR DESCRIPTION
 I have no idea how this got through but the SQL was invalid causing migration upgrades impossible.