### PR TITLE
Use intro info in position 1 as community image

### DIFF
--- a/url1/event_today.py
+++ b/url1/event_today.py
@@ -19,8 +19,7 @@ def set_current_community_photo():
             return
 
         # Pick at random
-        idx = random.randint(0, len(photos) - 1)
-        photo_name = photos[idx]
+        photo_name = random.choice(photos)
 
         full_path = os.path.join(config.community_photos_dir, photo_name)
         first_intro_info_id = (

--- a/url1/event_today.py
+++ b/url1/event_today.py
@@ -12,20 +12,24 @@ import shutil
 def set_current_community_photo():
     """As of June 2026, the first image seen when loading up Wii Room will be one uploaded by the community
     in the Discord server. We cycle through selected images every 24h at random."""
-    photos = os.listdir(config.community_photos_dir)
-    if len(photos) == 0:
-        # Empty, do nothing
-        return
+    with app.app_context():
+        photos = os.listdir(config.community_photos_dir)
+        if len(photos) == 0:
+            # Empty, do nothing
+            return
 
-    # Pick at random
-    idx = random.randint(0, len(photos) - 1)
-    photo_name = photos[idx]
+        # Pick at random
+        idx = random.randint(0, len(photos) - 1)
+        photo_name = photos[idx]
 
-    full_path = os.path.join(config.community_photos_dir, photo_name)
-    intro_assets_path = f"assets/normal-intro/1-1.img"
+        full_path = os.path.join(config.community_photos_dir, photo_name)
+        first_intro_info_id = (
+            IntroInfo.query.order_by(IntroInfo.position.asc()).first().cnt_id
+        )
+        intro_assets_path = f"assets/normal-intro/{first_intro_info_id}-1.img"
 
-    # Copy and rename image
-    shutil.copy(full_path, intro_assets_path)
+        # Copy and rename image
+        shutil.copy(full_path, intro_assets_path)
 
 
 @app.route("/url1/event/today.xml")


### PR DESCRIPTION
Previously the photo id was hardcoded to ID 1, while in most cases this is probably true as we never edited the original intro image, this is bad practice.