### PR TITLE
Shift IntroInfo position when one is deleted

### DIFF
--- a/theunderground/intro_info.py
+++ b/theunderground/intro_info.py
@@ -171,6 +171,11 @@ def edit_intro_info(id):
 @oidc.require_login
 def remove_intro_info(id):
     def drop_intro_info():
+        # All positioning after the current info needs to be updated.
+        infos = IntroInfo.query.filter(IntroInfo.position > current_info.position).all()
+        for info in infos:
+            info.position -= 1
+
         db.session.delete(current_info)
         db.session.commit()
 


### PR DESCRIPTION
Currently, the position is not shifted to reflect when an IntroInfo is deleted. This does not impact the channel because we set the position using index rather than what is stored in the database.

The issue arises when a user tries to move an IntroInfo up or down. If for instance IntroInfo 21 is deleted and I want to move IntroInfo 22 down, that would not work as IntroInfo 21 no longer exists. This PR fixes that by editing the position of every IntroInfo after the deleted one to be one less than current.