### PR TITLE
Convert room_menu to jsonb

### DIFF
--- a/migrations/versions/70ae2a4487d5_convert_room_data_to_jsonb.py
+++ b/migrations/versions/70ae2a4487d5_convert_room_data_to_jsonb.py
@@ -1,0 +1,30 @@
+"""Convert room_data to jsonb
+
+Revision ID: 70ae2a4487d5
+Revises: 9a3ca245cede
+Create Date: 2026-06-27 15:59:14.509899
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "70ae2a4487d5"
+down_revision = "9a3ca245cede"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """ALTER TABLE room_menu ALTER COLUMN data TYPE jsonb using data::jsonb"""
+    )
+    # ### end Alembic commands ###
+
+
+def downgrade():
+
+    op.execute("""ALTER TABLE room_menu ALTER COLUMN data TYPE text using data::text""")
+    # ### end Alembic commands ###

--- a/models.py
+++ b/models.py
@@ -2,9 +2,9 @@ import enum
 
 from flask_sqlalchemy import SQLAlchemy
 from flask_sqlalchemy.query import Query
-from sqlalchemy import func, String, ForeignKey, LargeBinary, BigInteger
+from sqlalchemy import func, String, ForeignKey, LargeBinary, BigInteger, JSON
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy.types import TypeDecorator
 from sqlalchemy_searchable import make_searchable
 from sqlalchemy_utils import TSVectorType
 from datetime import datetime
@@ -16,26 +16,12 @@ import json
 db = SQLAlchemy()
 
 
-class DictType(TypeDecorator):
-    impl = sqlalchemy.Text()
-
-    def process_bind_param(self, value, dialect):
-        if value is not None:
-            value = json.dumps(value)
-
-        return value
-
-    def process_result_value(self, value, dialect):
-        if value is not None:
-            value = json.loads(value)
-        return value
-
-
 class RoomMenu(db.Model):
     id: Mapped[int] = mapped_column(primary_key=True, unique=True)
     room_id: Mapped[int]
-    data = db.Column(DictType)  # This is a dict with keys in it for that type.
-    # TODO: Figure out a suitable UI, maybe even using Javascript?
+    data: Mapped[bytes] = mapped_column(
+        JSONB
+    )  # This is a dict with keys in it for that type.
 
 
 class Posters(db.Model):


### PR DESCRIPTION
PostgreSQL has built in JSON types (`json` and `jsonb`). Currently, the `room_menu` column in `room_data` used a custom wrapper. This changes the column type to `jsonb` which is JSON stored as a byte object. We don't require querying by JSON key so this is fine