### PR TITLE
 Upload movies relative to category page

### DIFF
--- a/templates/movie_action.html
+++ b/templates/movie_action.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <h1 class="mb-6 text-2xl font-bold text-white">{{ action }} Movie</h1>
+    <h1 class="mb-6 text-2xl font-bold text-white">{{ action }} Movie for category: {{ category_name }}</h1>
 
     <div class="relative group mb-10">
         <div class="relative bg-gray-800 rounded-lg shadow-lg overflow-hidden border border-gray-700 p-8">
@@ -50,21 +50,7 @@
                     </div>
                 </div>
 
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div>
-                        <label for="{{ form.category.id }}"
-                            class="block text-sm font-medium text-gray-300 mb-2">Category:</label>
-                        <div class="relative rounded-md shadow-sm">
-                            <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                                <img src="/static/icon/folder.svg" alt="Category" class="w-5 h-5 invert opacity-70" />
-                            </div>
-                            {{ form.category(class_="bg-gray-700 border border-gray-600 text-white pl-10 w-full px-4
-                            py-2 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500
-                            focus:border-transparent appearance-none") }}
-                        </div>
-                        <p class="mt-1 text-xs text-gray-400">Classification category for the movie</p>
-                    </div>
-
+                <div class="grid grid-cols-1 md:grid-cols-1 gap-6">
                     <div>
                         <label for="{{ form.room.id }}"
                             class="block text-sm font-medium text-gray-300 mb-2">Room:</label>

--- a/templates/movie_list.html
+++ b/templates/movie_list.html
@@ -44,7 +44,7 @@
                     </div>
                     <h2 class="text-xl font-bold text-white">Movie Management - {{ category_name }}</h2>
                 </div>
-                <a href="{{ url_for('add_movie') }}"
+                <a href="{{ url_for('add_movie', category_id=category_id) }}"
                     class="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg transition duration-200 inline-flex items-center text-sm">
                     <img src="/static/icon/plus.svg" alt="Add" class="h-4 w-4 mr-2 invert" />
                     <span>Add Movie</span>
@@ -60,7 +60,7 @@
                 <p class="text-sm text-gray-500 max-w-sm mx-auto mb-6">
                     This category doesn't have any movies yet.
                 </p>
-                <a href="{{ url_for('add_movie') }}"
+                <a href="{{ url_for('add_movie', category_id=category_id) }}"
                     class="inline-flex items-center px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg transition duration-200 text-sm">
                     <img src="/static/icon/circle-plus.svg" alt="Create" class="h-5 w-5 mr-2 invert" />
                     <span>Add Your First Movie</span>
@@ -89,7 +89,7 @@
                             <td class="px-6 py-4">
                                 <div class="flex items-center space-x-4">
                                     <div class="flex-shrink-0 relative h-20 w-36 rounded-lg overflow-hidden border border-gray-600 shadow-md">
-                                        <img src="{{ url_for('get_movie_thumbnail', movie_id=movie.movie_id) }}" 
+                                        <img src="{{ url_for('get_movie_thumbnail', category_id=category_id, movie_id=movie.movie_id) }}"
                                              alt="Thumbnail for {{ movie.movie_id }}" 
                                              class="h-full w-full object-cover" />
                                              
@@ -155,7 +155,7 @@
                             <td class="px-6 py-4">
                                 <div class="flex flex-col gap-2">
                                     <div class="flex flex-wrap gap-2">
-                                        <a href="{{ url_for('edit_movie', movie_id=movie.movie_id) }}"
+                                        <a href="{{ url_for('edit_movie', category_id=category_id, movie_id=movie.movie_id) }}"
                                             class="inline-flex items-center px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg transition duration-200 text-xs">
                                             <img src="/static/icon/pencil.svg" alt="Edit" class="h-3.5 w-3.5 mr-1.5 invert" />
                                             <span>Edit</span>
@@ -167,7 +167,7 @@
                                             <span>Toggle</span>
                                         </a>
                                         
-                                        <a href="{{ url_for('remove_movie', movie_id=movie.movie_id) }}"
+                                        <a href="{{ url_for('remove_movie', category_id=category_id, movie_id=movie.movie_id) }}"
                                             class="inline-flex items-center px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded-lg transition duration-200 text-xs">
                                             <img src="/static/icon/trash.svg" alt="Delete" class="h-3.5 w-3.5 mr-1.5 invert" />
                                             <span>Delete</span>
@@ -175,14 +175,14 @@
                                     </div>
                                     
                                     <div class="flex flex-wrap gap-2">
-                                        <a href="{{ url_for('save_movie', movie_id=movie.movie_id) }}"
+                                        <a href="{{ url_for('save_movie', category_id=category_id, movie_id=movie.movie_id) }}"
                                             class="inline-flex items-center px-2.5 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition duration-200 text-xs">
                                             <img src="/static/icon/download.svg" alt="Download" class="h-3.5 w-3.5 mr-1 invert" />
                                             <span>Wii</span>
                                         </a>
                                         
                                         {% if movie.ds_mov_id is not none %}
-                                        <a href="{{ url_for('save_ds_movie', movie_id=movie.movie_id) }}"
+                                        <a href="{{ url_for('save_ds_movie', category_id=category_id, movie_id=movie.movie_id) }}"
                                             class="inline-flex items-center px-2.5 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition duration-200 text-xs">
                                             <img src="/static/icon/download.svg" alt="Download DS" class="h-3.5 w-3.5 mr-1 invert" />
                                             <span>DSi</span>

--- a/theunderground/forms.py
+++ b/theunderground/forms.py
@@ -60,7 +60,6 @@ class MovieUploadForm(FlaskForm):
         coerce=MovieGenres.coerce,
     )
     # Choices for the select field are only evaluated once, so we must set it when necessary.
-    category = SelectField("Movie category", validators=[DataRequired()])
     room = SelectField("Room", validators=[DataRequired()])
     upload = SubmitField("Add Movie")
 

--- a/theunderground/mobiclip.py
+++ b/theunderground/mobiclip.py
@@ -12,7 +12,7 @@ import config
 from time import gmtime, strftime
 
 from room import s3
-from models import Categories, PayCategories, Rooms
+from models import Categories, PayCategories, Rooms, db
 from theunderground.encodemii import (
     movie_thumbnail_encode,
     pay_movie_thumbnail_encode,
@@ -115,18 +115,8 @@ def validate_mobi_dsi(file_data: bytes) -> Union[bool, bytes]:
     return True
 
 
-def get_category_list():
-    db_categories = Categories.query.all()
-
-    choice_categories = []
-    for _, category in enumerate(db_categories):
-        choice_categories.append([category.category_id, category.name])
-
-    return choice_categories
-
-
-def get_room_list():
-    db_rooms = Rooms.query.all()
+def get_room_list(locale):
+    db_rooms = db.session.query(Rooms).where(Rooms.locale == locale).all()
 
     choice_rooms = []
     for _, room in enumerate(db_rooms):

--- a/theunderground/movies.py
+++ b/theunderground/movies.py
@@ -12,7 +12,6 @@ from werkzeug import exceptions
 from models import Movies, db, MovieCredits, Categories
 from room import app
 from theunderground.mobiclip import (
-    get_category_list,
     validate_mobiclip,
     validate_mobi_dsi,
     get_mobiclip_length,
@@ -47,9 +46,10 @@ def list_movies(category):
     )
 
     unlisted_movies = (
-        Movies.query.filter(Movies.category_id == category)
+        db.session.query(Movies)
+        .filter(Movies.category_id == category)
         .filter(Movies.unlisted == True)
-        .all()
+        .count()
     )
 
     category_name = db.session.scalar(
@@ -61,12 +61,12 @@ def list_movies(category):
         movies=movies,
         category_id=category,
         category_name=category_name,
-        type_length=movies.total - len(unlisted_movies),
+        type_length=movies.total - unlisted_movies,
         type_max_count=64,
     )
 
 
-@app.route("/theunderground/movies/<category>/<movie_id>/listed")
+@app.route("/theunderground/categories/<category>/<movie_id>/listed")
 @oidc.require_login
 def toggle_movie_listed(category, movie_id):
     movie = db.session.query(Movies).filter_by(movie_id=movie_id).first()
@@ -75,12 +75,19 @@ def toggle_movie_listed(category, movie_id):
     return redirect(url_for("list_movies", category=category))
 
 
-@app.route("/theunderground/movies/add", methods=["GET", "POST"])
+@app.route("/theunderground/categories/<int:category_id>/add", methods=["GET", "POST"])
 @oidc.require_login
-def add_movie():
+def add_movie(category_id: int):
+    category_obj = (
+        db.session.query(Categories)
+        .filter(Categories.category_id == category_id)
+        .first()
+    )
+    if not category_obj:
+        return exceptions.NotFound()
+
     form = MovieUploadForm()
-    form.category.choices = get_category_list()
-    form.room.choices = get_room_list()
+    form.room.choices = get_room_list(category_obj.locale)
     form.movie.validators = [FileRequired()]
     form.thumbnail.validators = [FileRequired()]
 
@@ -101,7 +108,7 @@ def add_movie():
                 # For right now, we will assume defaults.
                 db_movie = Movies(
                     title=form.title.data,
-                    category_id=form.category.data,
+                    category_id=category_id,
                     length=length,
                     aspect=True,
                     genre=form.genre.data,
@@ -131,29 +138,41 @@ def add_movie():
 
                 # Finally update the category if needed by S3
                 if s3:
-                    cat_xml = list_category_search(form.category.data)
-                    xml_path = f"list/category/search/{form.category.data}"
+                    cat_xml = list_category_search(category_id)
+                    xml_path = f"list/category/search/{category_id}"
                     s3.upload_fileobj(BytesIO(cat_xml), config.r2_bucket_name, xml_path)
 
                 log_action(f"Movie ID {db_movie.movie_id} added")
-                return redirect(url_for("list_categories"))
+                return redirect(url_for("list_movies", category=category_id))
             else:
                 flash("Invalid movie!")
         else:
             flash("Error uploading movie!")
 
-    return render_template("movie_action.html", form=form, action="Add")
+    return render_template(
+        "movie_action.html", form=form, action="Add", category_name=category_obj.name
+    )
 
 
-@app.route("/theunderground/movies/<movie_id>/edit", methods=["GET", "POST"])
+@app.route(
+    "/theunderground/categories/<int:category_id>/<int:movie_id>/edit",
+    methods=["GET", "POST"],
+)
 @oidc.require_login
-def edit_movie(movie_id):
+def edit_movie(category_id: int, movie_id: int):
+    category_obj = (
+        db.session.query(Categories)
+        .filter(Categories.category_id == category_id)
+        .first()
+    )
+    if not category_obj:
+        return exceptions.NotFound()
+
     form = MovieUploadForm()
-    form.category.choices = get_category_list()
-    form.room.choices = get_room_list()
+    form.room.choices = get_room_list(category_obj.locale)
     form.upload.label.text = "Edit"
 
-    movie = Movies.query.filter_by(movie_id=movie_id).first()
+    movie = db.session.query(Movies).filter_by(movie_id=movie_id).first()
     if not movie:
         return exceptions.NotFound()
 
@@ -168,7 +187,12 @@ def edit_movie(movie_id):
                 movie.length = length
             else:
                 flash("Invalid movie")
-                return render_template("movie_action.html", form=form, action="Edit")
+                return render_template(
+                    "movie_action.html",
+                    form=form,
+                    action="Edit",
+                    category_name=category_obj.name,
+                )
 
         if form.thumbnail.data:
             thumbnail_data = form.thumbnail.data.read()
@@ -182,7 +206,12 @@ def edit_movie(movie_id):
 
             if not validation_ds:
                 flash("Invalid DS movie")
-                return render_template("movie_action.html", form=form, action="Edit")
+                return render_template(
+                    "movie_action.html",
+                    form=form,
+                    action="Edit",
+                    category_name=category_obj.name,
+                )
 
             movie.ds_mov_id = movie.movie_id
 
@@ -191,30 +220,36 @@ def edit_movie(movie_id):
         # Finally update the title, genre and category.
         movie.title = form.title.data
         movie.genre = form.genre.data
-        movie.category_id = form.category.data
         movie.sp_page_id = form.room.data
         db.session.commit()
 
         if s3:
-            cat_xml = list_category_search(form.category.data)
-            xml_path = f"list/category/search/{form.category.data}"
+            cat_xml = list_category_search(category_id)
+            xml_path = f"list/category/search/{category_id}"
             s3.upload_fileobj(BytesIO(cat_xml), config.r2_bucket_name, xml_path)
 
         log_action(f"Movie ID {movie_id} edited")
-        return redirect(url_for("list_categories"))
+        return redirect(url_for("list_movies", category=category_id))
     else:
         form.title.data = movie.title
         form.genre.data = movie.genre
-        form.category.data = movie.category_id
+        form.room.data = form.room.coerce(movie.sp_page_id)
 
     return render_template(
-        "movie_action.html", form=form, action="Edit", movie_id=movie_id
+        "movie_action.html",
+        form=form,
+        action="Edit",
+        movie_id=movie_id,
+        category_name=category_obj.name,
     )
 
 
-@app.route("/theunderground/movies/<movie_id>/save", methods=["GET", "POST"])
+@app.route(
+    "/theunderground/categories/<int:category_id>/<int:movie_id>/save",
+    methods=["GET", "POST"],
+)
 @oidc.require_login
-def save_movie(movie_id):
+def save_movie(category_id: int, movie_id: int):
     movie_dir = get_movie_path(movie_id)
     if s3:
         return redirect(f"{config.url1_cdn_url}/{movie_dir}/{movie_id}-H.mov")
@@ -222,9 +257,12 @@ def save_movie(movie_id):
     return send_from_directory(movie_dir, f"{movie_id}-H.mov")
 
 
-@app.route("/theunderground/movies/<movie_id>/save_ds", methods=["GET", "POST"])
+@app.route(
+    "/theunderground/categories/<int:category_id>/<int:movie_id>/save_ds",
+    methods=["GET", "POST"],
+)
 @oidc.require_login
-def save_ds_movie(movie_id):
+def save_ds_movie(category_id: int, movie_id: int):
     ds_movie_dir = get_ds_movie_path(movie_id)
     if s3:
         return redirect(f"{config.url1_cdn_url}/{ds_movie_dir}/{movie_id}.enc")
@@ -232,14 +270,17 @@ def save_ds_movie(movie_id):
     return send_from_directory(ds_movie_dir, f"{movie_id}.enc")
 
 
-@app.route("/theunderground/movies/<movie_id>/remove", methods=["GET", "POST"])
+@app.route(
+    "/theunderground/categories/<int:category_id>/<int:movie_id>/remove",
+    methods=["GET", "POST"],
+)
 @oidc.require_login
-def remove_movie(movie_id):
+def remove_movie(category_id: int, movie_id: int):
     def drop_movie():
         # Remove the credits first
-        MovieCredits.query.filter_by(movie_id=movie_id).delete()
+        db.session.query(MovieCredits).filter_by(movie_id=movie_id).delete()
 
-        movie = Movies.query.filter_by(movie_id=movie_id).first()
+        movie = db.session.query(Movies).filter_by(movie_id=movie_id).first()
         has_ds = movie.ds_mov_id is not None
         db.session.delete(movie)
         db.session.commit()
@@ -247,14 +288,14 @@ def remove_movie(movie_id):
         delete_movie_data(movie_id, has_ds)
 
         log_action(f"Movie ID {movie_id} removed")
-        return redirect(url_for("list_categories"))
+        return redirect(url_for("list_movies", category=category_id))
 
     return manage_delete_item(movie_id, "movie", drop_movie)
 
 
-@app.route("/theunderground/movies/<movie_id>/thumbnail.jpg")
+@app.route("/theunderground/categories/<int:category_id>/<int:movie_id>/thumbnail.jpg")
 @oidc.require_login
-def get_movie_thumbnail(movie_id):
+def get_movie_thumbnail(category_id: int, movie_id: int):
     movie_dir = get_movie_path(movie_id)
     if s3:
         return redirect(f"{config.url1_cdn_url}/{movie_dir}/{movie_id}.img")


### PR DESCRIPTION
Currently on the movie upload screen, rooms show regardless of language. This means that someone can very easily select a room that is not in the same region as the category they want to upload to, causing issues on the channel's side.

This PR fixes that by:
1) Making all movie paths include the selected category. This also gives us some consistency with the movie paths.
2) With the changes set forth in (1), I already have the category ID of the category that the movie is being uploaded to, meaning we do not need the category select dropdown.

tl;dr: Content has to select the category they want to upload, then click upload movie in order to upload a movie to the correct category.

Pay Movies are not being touched as I have to fully rework how they work.